### PR TITLE
Allow mutable string literals in specs.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,10 @@ Lint/UnusedBlockArgument:
 Style/ClassAndModuleChildren:
   EnforcedStyle: 'compact'
 
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - "**/**/*_spec.rb"
+
 Style/SymbolArray:
   EnforcedStyle: brackets
 


### PR DESCRIPTION
Bypass enforcement of frozen string literals within specs to provide workaround for acaprojects/ruby-engine#10.