### PR TITLE
(aca:osd) add logic module for OSD comms proxy

### DIFF
--- a/modules/aca/osd_logic.rb
+++ b/modules/aca/osd_logic.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Aca; end
+
+class Aca::OsdLogic
+    include ::Orchestrator::Constants
+
+    implements :logic
+    descriptive_name 'ACA On Screen Display Logic'
+    generic_name :OSD
+
+    def on_load
+        on_update
+    end
+
+    def on_update
+        clear_message
+        stream setting(:stream_url)
+    end
+
+    def hdmi
+        self.stream = 'tv:brightsign.biz/hdmi'
+    end
+
+    def stream(url)
+        self.stream = url
+    end
+
+    def show_message(message, timeout = '10s')
+        schedule.clear
+
+        self.message = message
+
+        schedule.in(timeout) { clear_message } unless is_negatory? timeout
+    end
+
+    def clear_message
+        self.message = ''
+    end
+
+    protected
+
+    def stream=(address)
+        self[:stream_url] = address
+        define_setting(:stream_url, address)
+    end
+
+    def message=(msg)
+        self[:message] = msg
+    end
+end


### PR DESCRIPTION
# Description
Basic logic module for proxying comms to a Brightsign based OSD.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New device driver
- [ ] New service driver
- [x] New logic driver
- [ ] Driver update (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Has this been tested?

Check all that apply.

- [ ] As a mocked device with a spec
- [ ] With a physical device
