### PR TITLE
(module:schedules) use blocks as proc param is not supported

### DIFF
--- a/modules/aca/exchange_booking.rb
+++ b/modules/aca/exchange_booking.rb
@@ -188,7 +188,7 @@ class Aca::ExchangeBooking
 
         fetch_bookings
         schedule.clear
-        schedule.every(setting(:update_every) || '5m', method(:fetch_bookings))
+        schedule.every(setting(:update_every) || '5m') { fetch_bookings }
     end
 
 

--- a/modules/aca/findme_booking.rb
+++ b/modules/aca/findme_booking.rb
@@ -181,7 +181,7 @@ class Aca::FindmeBooking
 
         fetch_bookings
         schedule.clear
-        schedule.every(setting(:update_every) || '5m', method(:fetch_bookings))
+        schedule.every(setting(:update_every) || '5m') { fetch_bookings }
     end
 
 

--- a/modules/aca/google_booking.rb
+++ b/modules/aca/google_booking.rb
@@ -209,7 +209,7 @@ class Aca::GoogleBooking
 
         fetch_bookings
         schedule.clear
-        schedule.every(setting(:update_every) || '5m', method(:fetch_bookings))
+        schedule.every(setting(:update_every) || '5m') { fetch_bookings }
     end
 
 

--- a/modules/aca/google_refresh_booking.rb
+++ b/modules/aca/google_refresh_booking.rb
@@ -209,7 +209,7 @@ class Aca::GoogleRefreshBooking
 
         fetch_bookings
         schedule.clear
-        schedule.every(setting(:update_every) || '5m', method(:fetch_bookings))
+        schedule.every(setting(:update_every) || '5m') { fetch_bookings }
     end
 
 

--- a/modules/aca/office_booking.rb
+++ b/modules/aca/office_booking.rb
@@ -208,7 +208,7 @@ class Aca::OfficeBooking
 
         fetch_bookings
         schedule.clear
-        schedule.every(setting(:update_every) || '5m', method(:fetch_bookings))
+        schedule.every(setting(:update_every) || '5m') { fetch_bookings }
     end
 
 

--- a/modules/axis/camera/vapix.rb
+++ b/modules/axis/camera/vapix.rb
@@ -52,7 +52,7 @@ class Axis::Camera::Vapix
 
     
     def connected
-        schedule.every('60s', method(:do_poll))
+        schedule.every('60s') { do_poll }
         do_poll
     end
 

--- a/modules/epson/projector/esc_vp21.rb
+++ b/modules/epson/projector/esc_vp21.rb
@@ -38,7 +38,7 @@ class Epson::Projector::EscVp21
         # Have to init comms
         send("ESC/VP.net\x10\x03\x00\x00\x00\x00")
         do_poll
-        schedule.every('52s', method(:do_poll))
+        schedule.every('52s') { do_poll }
     end
 
     def disconnected

--- a/modules/panasonic/camera/he50.rb
+++ b/modules/panasonic/camera/he50.rb
@@ -53,7 +53,7 @@ class Panasonic::Camera::He50
     end
 
     def connected
-        schedule.every('60s', method(:do_poll))
+        schedule.every('60s') { do_poll }
         do_poll
     end
 

--- a/modules/sony/display/id_talk.rb
+++ b/modules/sony/display/id_talk.rb
@@ -38,7 +38,7 @@ class Sony::Display::IdTalk
     
 
     def connected
-        schedule.every('60s', method(:do_poll))
+        schedule.every('60s') { do_poll }
     end
 
     def disconnected

--- a/modules/sony/projector/pj_talk.rb
+++ b/modules/sony/projector/pj_talk.rb
@@ -38,7 +38,7 @@ class Sony::Projector::PjTalk
     
 
     def connected
-        schedule.every('60s', method(:do_poll))
+        schedule.every('60s') { do_poll }
     end
 
     def disconnected


### PR DESCRIPTION
not supported on the latest version of engine anymore. This method is
more performant, easier to read and means that live updates work as
they should as the method method creates a reference to the method at
the time of calling, whereas the using a proc it runs the latest
version of the method

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)


## Type of change

  [ ] Bug fix (non-breaking change which fixes an issue)
  [ ] New device driver
  [ ] New service driver
  [ ] New logic driver
  [ ] Driver update (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Has this been tested?

Check all that apply.

- [ ] As a mocked device with a spec
- [ ] With a physical device
