### PR TITLE
(ibm:domino) New bookings, don't append AV Control URL to booking decription

### DIFF
--- a/lib/ibm/domino.rb
+++ b/lib/ibm/domino.rb
@@ -216,10 +216,10 @@ class Ibm::Domino
             description = ""
         end
 
-        if room.support_url
-            description = description + "\nTo control this meeting room, click here: #{room.support_url}"
-            event[:description] = description
-        end
+        #if room.support_url
+        #    description = description + "\nTo control this meeting room, click here: #{room.support_url}"
+        #    event[:description] = description
+        #end
 
         event[:attendees] = Array(attendees).collect do |attendee|
             out_attendee = {


### PR DESCRIPTION
Comment out section that automatically appends Engine System's support_url to the booking description. 