### PR TITLE
Signal router

### DIFF
--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -31,7 +31,11 @@ class Aca::Router
     end
 
     def on_update
-        load_from_map setting(:connections)
+        connections = setting :connections
+
+        logger.warn 'no connections defined' unless connections
+
+        load_from_map(connections || {})
     end
 
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -224,7 +224,7 @@ class Aca::Router
 
                     source_nodes |= nodes
                     edge_map[source][sink] = edges
-                rescue e
+                rescue => e
                     # note `route` may also throw an exception (e.g. when there
                     # is an invalid source / sink or unroutable path)
                     raise if atomic

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -103,7 +103,7 @@ class Aca::Router
             node = predecessor
         end
 
-        logger.debug { nodes.join ' ---> ' }
+        logger.debug { edges.map(&:to_s).join ' then ' }
 
         [nodes, edges]
     end
@@ -181,6 +181,10 @@ class Aca::Router::SignalGraph
             else
                 system[device].switch input => output
             end
+        end
+
+        def to_s
+            "#{target} to #{device} (in #{input})"
         end
     end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -280,7 +280,7 @@ class Aca::Router
             if mod.nil? && single_source
 
         fail_with['already on correct input'] \
-            if edge.nx1? && mod[:input] == edge.input && !force
+            if edge.nx1? && mod && mod[:input] == edge.input && !force
 
         fail_with['has an incompatible api, but only a single input defined'] \
             if edge.nx1? && !mod.respond_to?(:switch_to) && single_source

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -258,6 +258,18 @@ class Aca::Router::SignalGraph
     Paths = Struct.new :distance_to, :predecessor
 
     Edge = Struct.new :source, :target, :device, :input, :output do
+        def device=(device)
+            super(device.try(:to_sym) || device)
+        end
+
+        def input=(input)
+            super(input.try(:to_sym) || input)
+        end
+
+        def output=(output)
+            super(output.try(:to_sym) || output)
+        end
+
         def to_s
             "#{target} to #{device} (in #{input})"
         end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -98,7 +98,7 @@ class Aca::Router
         edges.last.input
     end
 
-    # Get the device and associated input immediately upstream of a node.
+    # Get the device and associated input immediately upstream of an input node.
     #
     # Depending on the device API, this may be of use for determining signal
     # presence.
@@ -106,16 +106,36 @@ class Aca::Router
         if sink.nil?
             edges = signal_graph.incoming_edges source
             unless edges.size == 1
-                raise ArgumentError "more than one edge to #{source} " \
+                raise ArgumentError, "more than one edge to #{source}, " \
                     'please specify a sink'
             end
-            edge = edges.values.first
+            _, edge = edges.first
         else
             _, edges = route source, sink
             edge = edges.first
         end
 
         [edge.device, edge.input]
+    end
+
+    # Get the device immediately preceeding an output node.
+    #
+    # This may be used walking back up the signal graph to find a decoder for
+    # and output device.
+    def downstream(sink, source = nil)
+        if source.nil?
+            edges = signal_graph.outgoing_edges sink
+            unless edges.size == 1
+                raise ArgumentError, "more than one input to #{sink}, " \
+                    'please specify a source'
+            end
+            _, edge = edges.first
+        else
+            _, edges = route source, sink
+            edge = edges.last
+        end
+
+        edge.target
     end
 
     protected

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -179,10 +179,10 @@ class Aca::Router
     def activate(edge)
         mod = system[edge.device]
 
-        if edge.nx1? && mod.respond_to(:switch_to)
+        if edge.nx1? && mod.respond_to?(:switch_to)
             mod.switch_to edge.input
 
-        elsif edge.nxn? && mod.respond_to(:switch)
+        elsif edge.nxn? && mod.respond_to?(:switch)
             mod.switch edge.input => edge.output
 
         elsif edge.nx1? && signal_graph.outdegree(edge.source) == 1

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -374,10 +374,8 @@ class Aca::Router::SignalGraph
     # to false to keep this O(1) rather than O(n). Using this flag at any other
     # time will result a corrupt structure.
     def delete(id, check_incoming_edges: true)
-        nodes.except! id
-
+        nodes.delete(id) { raise ArgumentError, "\"#{id}\" does not exist" }
         each { |node| node.edges.delete id } if check_incoming_edges
-
         self
     end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -552,13 +552,13 @@ class Aca::Router::SignalGraph
     # `device as output` to simply `output` and return a Hash of the structure
     # `{ output: device }`.
     def self.extract_mods!(map)
-        mods = {}
+        mods = HashWithIndifferentAccess.new
 
         map.transform_keys! do |key|
-            mod, node = key.to_s.split(' as ').map(&:to_sym)
+            mod, node = key.to_s.split(' as ')
             node ||= mod
             mods[node] = mod
-            node
+            node.to_sym
         end
 
         mods

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -78,7 +78,7 @@ class Aca::Router
         check_conflicts routes, strict: atomic
 
         edges = routes.values.map(&:second).reduce(&:|)
-        interactions = edges.map { |e| activate e, force: force }
+        interactions = edges.map { |e| activate e, force }
         thread.finally(interactions).then do |results|
             _, failed = results.partition(&:last)
             if failed.empty?
@@ -222,7 +222,7 @@ class Aca::Router
         end
     end
 
-    def activate(edge, force: false)
+    def activate(edge, force = false)
         mod = system[edge.device]
 
         if edge.nx1? && mod.respond_to?(:switch_to)

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -290,9 +290,16 @@ class Aca::Router::SignalGraph
             @target = target
 
             meta = Meta.new.tap(&blk)
+            normalise_io = lambda do |x|
+                if x.is_a? String
+                    x[/^\d+$/]&.to_i || x.to_sym
+                else
+                    x
+                end
+            end
             @device = meta.device&.to_sym
-            @input  = meta.input.try(:to_sym) || meta.input
-            @output = meta.output.try(:to_sym) || meta.output
+            @input  = normalise_io[meta.input]
+            @output = normalise_io[meta.output]
         end
 
         def to_s

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -448,11 +448,11 @@ class Aca::Router::SignalGraph
     # Pre-parse a connection map into a normalised nested hash structure
     # suitable for parsing into the graph.
     #
-    # This assums the input map has come from passed JSON so takes care of
+    # This assumes the input map has been parsed from JSON so takes care of
     # mapping keys back to integers (where suitable) and expanding sources
     # specified as an array into a nested Hash. The target normalised output is
     #
-    #     { output: { device_input: source } }
+    #     { device: { input: source } }
     #
     def self.normalise(map)
         map.with_indifferent_access.transform_values! do |inputs|
@@ -492,7 +492,7 @@ class Aca::Router::SignalGraph
     #   or
     #     { device: [source] }
     #
-    # When inputs are specified as an array, 1-based indicies will be used.
+    # When inputs are specified as an array, 1-based indices will be used.
     #
     # Sources that refer to the output of a matrix switcher are defined as
     # "device__output" (using two underscores to seperate the output

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -66,7 +66,7 @@ class Aca::Router
     # 'atomic'      may be used to throw an exception, prior to any device
     #               interaction taking place if any of the routes are not
     #               possible
-    # `force`       may be used to force all switching, regardless of if the
+    # `force`       control if switch events should be forced, even when the
     #               associated device module is already reporting it's on the
     #               correct input
     #

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -95,9 +95,11 @@ class Aca::Router
                 signal_map
             else
                 failed.each do |edge, (error, _)|
-                    logger.error "could not switch #{edge}: #{error}"
+                    logger.warn "could not switch #{edge}: #{error}"
                 end
-                thread.reject 'failed to activate all routes'
+                message = 'failed to activate all routes'
+                logger.error message
+                thread.reject message
             end
         end
     end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -161,9 +161,9 @@ class Aca::Router
         @signal_graph = SignalGraph.from_map(connections).freeze
 
         # TODO: track active signal source at each node and expose as a hash
-        self[:nodes] = signal_graph.map(&:id)
-        self[:inputs] = signal_graph.sinks.map(&:id)
-        self[:outputs] = signal_graph.sources.map(&:id)
+        self[:nodes] = signal_graph.node_ids
+        self[:inputs] = signal_graph.sinks
+        self[:outputs] = signal_graph.sources
     end
 
     # Find the shortest path between between two nodes and return a list of the
@@ -456,16 +456,20 @@ class Aca::Router::SignalGraph
         nodes.key? id
     end
 
+    def node_ids
+        map(&:id)
+    end
+
     def successors(id)
         nodes[id].edges.keys
     end
 
     def sources
-        select { |node| indegree(node.id).zero? }
+        node_ids.select { |id| indegree(id).zero? }
     end
 
     def sinks
-        select { |node| outdegree(node.id).zero? }
+        node_ids.select { |id| outdegree(id).zero? }
     end
 
     def incoming_edges(id)

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -90,9 +90,32 @@ class Aca::Router
 
     # Lookup the name of the input on a sink node that would be used to connect
     # a source to it.
+    #
+    # This can be used to register the source on devices such as codecs that
+    # support upstream switching.
     def input_for(source, sink)
         _, edges = route source, sink
         edges.last.input
+    end
+
+    # Get the device and associated input immediately upstream of a node.
+    #
+    # Depending on the device API, this may be of use for determining signal
+    # presence.
+    def upstream(source, sink = nil)
+        if sink.nil?
+            edges = signal_graph.incoming_edges source
+            unless edges.size == 1
+                raise ArgumentError "more than one edge to #{source} " \
+                    'please specify a sink'
+            end
+            edge = edges.values.first
+        else
+            _, edges = route source, sink
+            edge = edges.first
+        end
+
+        [edge.device, edge.input]
     end
 
     protected

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -100,54 +100,51 @@ class Aca::Router
         end
     end
 
-    # Lookup the name of the input on a sink node that would be used to connect
-    # a source to it.
+    # Lookup the input on a sink node that would be used to connect a specific
+    # source to it.
     #
-    # This can be used to register the source on devices such as codecs that
-    # support upstream switching.
-    def input_for(source, sink)
+    # `on` may be ommited if the source node has only one neighbour (e.g. is
+    # an input node) and you wish to query the phsycial input associated with
+    # it. Similarly `on` maybe used to look up the input used by any other node
+    # within the graph that would be used to show `source`.
+    def input_for(source, on: nil)
+        sink = on || upstream(source)
         _, edges = route source, sink
         edges.last.input
     end
 
-    # Get the device and associated input immediately upstream of an input node.
+    # Get the node immediately upstream of an input node.
     #
     # Depending on the device API, this may be of use for determining signal
     # presence.
     def upstream(source, sink = nil)
         if sink.nil?
             edges = signal_graph.incoming_edges source
-            unless edges.size == 1
-                raise ArgumentError, "more than one edge to #{source}, " \
-                    'please specify a sink'
-            end
-            _, edge = edges.first
+            raise "no outputs from #{source}" if edges.empty?
+            raise "multiple outputs from #{source}, please specify a sink" \
+                if edges.size > 1
         else
             _, edges = route source, sink
-            edge = edges.first
         end
 
-        [edge.device, edge.input]
+        edges.first.source
     end
 
-    # Get the device immediately preceeding an output node.
+    # Get the node immediately downstream of an output node.
     #
     # This may be used walking back up the signal graph to find a decoder for
-    # and output device.
+    # an output device.
     def downstream(sink, source = nil)
         if source.nil?
             edges = signal_graph.outgoing_edges sink
-            unless edges.size == 1
-                raise ArgumentError, "more than one input to #{sink}, " \
-                    'please specify a source'
-            end
-            _, edge = edges.first
+            raise "no inputs to #{sink}" if edges.empty?
+            raise "multiple inputs to #{sink}, please specify a source" \
+                if edges.size > 1
         else
             _, edges = route source, sink
-            edge = edges.last
         end
 
-        edge.target
+        edges.last.target
     end
 
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -388,13 +388,13 @@ class Aca::Router::SignalGraph
     end
 
     def incoming_edges(id)
-        reduce(HashWithIndifferentAccess.new) do |edges, node|
-            edges.tap { |e| e[node.id] = node.edges[id] if node.edges.key? id }
+        reduce([]) do |edges, node|
+            edges << node.edges[id] if node.edges.key? id
         end
     end
 
     def outgoing_edges(id)
-        nodes[id].edges
+        nodes[id].edges.values
     end
 
     def indegree(id)

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -217,7 +217,7 @@ class Aca::Router::SignalGraph
 
         # Check if the edge is a switchable input on a single output device
         def nx1?
-            edge.output.nil?
+            output.nil?
         end
 
         # Check if the edge a matrix switcher / multi-output device

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -173,7 +173,7 @@ class Aca::Router
         edges = []
         node = signal_graph[source]
         until node.nil?
-            nodes << node
+            nodes.unshift node
             predecessor = path.predecessor[node.id]
             edges << predecessor.edges[node.id] unless predecessor.nil?
             node = predecessor

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -82,6 +82,7 @@ class Aca::Router
         check_conflicts routes, strict: atomic
 
         edges = routes.values.map(&:second).reduce(&:|)
+
         edges, unroutable = edges.partition { |e| can_activate? e }
         raise 'can not perform all routes' if unroutable.any? && atomic
 
@@ -89,7 +90,7 @@ class Aca::Router
 
         thread.finally(interactions).then do |results|
             failed = edges.zip(results).reject { |_, (_, resolved)| resolved }
-            if failed.empty?
+            if (failed + unroutable).empty?
                 logger.debug 'all routes activated successfully'
                 signal_map
             else

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -139,6 +139,9 @@ class Aca::Router
 
     def check_conflicts(routes, strict: false)
         nodes = routes.values.map(&:first)
+
+        return Set.new if nodes.size <= 1
+
         nodes.reduce(&:&).tap do |conflicts|
             unless conflicts.empty?
                 nodes = conflicts.map(&:to_s).join ', '

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -73,7 +73,7 @@ class Aca::Router
     end
 
     def paths
-        @path_cache ||= Hash.new do |hash, node|
+        @path_cache ||= HashWithIndifferentAccess.new do |hash, node|
             hash[node] = signal_graph.dijkstra node
         end
     end
@@ -257,7 +257,7 @@ class Aca::Router::SignalGraph
 
     def dijkstra(id)
         active = Containers::PriorityQueue.new { |x, y| (x <=> y) == -1 }
-        distance_to = Hash.new { 1.0 / 0.0 }
+        distance_to = HashWithIndifferentAccess.new { 1.0 / 0.0 }
         predecessor = {}
 
         distance_to[id] = 0

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -61,7 +61,15 @@ class Aca::Router
             "Nodes to connect: #{nodes}"
         end
 
-        # Check for intersections / conflicts across sources
+        # Check for intersecting paths across sources
+        routes.values.map(&:first).reduce(&:&).tap do |conflicts|
+            unless conflicts.empty?
+                nodes = conflicts.map(&:to_s).join ', '
+                message = "conflicting signal paths found for #{nodes}"
+                raise ArgumentError, message if atomic
+                logger.warn message
+            end
+        end
 
         # 3. Perform device interactions
         # 4. Consolidate each path into a success / fail

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -158,7 +158,9 @@ class Aca::Router::SignalGraph
     attr_reader :nodes
 
     def initialize
-        @nodes = ActiveSupport::HashWithIndifferentAccess.new
+        @nodes = ActiveSupport::HashWithIndifferentAccess.new do |_, id|
+            raise ArgumentError, "\"#{id}\" does not exist"
+        end
     end
 
     def [](id)
@@ -166,7 +168,7 @@ class Aca::Router::SignalGraph
     end
 
     def insert(id)
-        nodes[id] ||= Node.new id
+        nodes[id] = Node.new id unless nodes.key? id
         self
     end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -80,10 +80,10 @@ class Aca::Router
             _, failed = results.partition(&:last)
             if failed.empty?
                 logger.debug 'all routes activated successfully'
-                :success
+                signal_map
             else
                 failed.each { |result, _| logger.error result }
-                thread.defer.reject 'failed to activate all routes'
+                thread.reject 'failed to activate all routes'
             end
         end
     end
@@ -231,10 +231,10 @@ class Aca::Router
         elsif edge.nx1? && signal_graph.outdegree(edge.source) == 1
             logger.warn "cannot perform switch on #{edge.device}. " \
                 "This may be ok as only one input (#{edge.target}) is defined."
-            thread.defer.resolve
+            thread.defer.resolve.promise
 
         else
-            thread.defer.reject "cannot interact with #{edge.device}. " \
+            thread.reject "cannot interact with #{edge.device}. " \
                 'Module may be offline or incompatible.'
         end
     end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -16,10 +16,15 @@ class Aca::Router
         devices and complex/layered switching infrastructure.
     DESC
 
+
     default_settings(
         # Nested hash of signal connectivity. See SignalGraph.from_map.
         connections: {}
     )
+
+
+    # ------------------------------
+    # Callbacks
 
     def on_load
         on_update
@@ -50,6 +55,10 @@ class Aca::Router
         self[:inputs] = signal_graph.sinks.map(&:id)
         self[:outputs] = signal_graph.sources.map(&:id)
     end
+
+
+    # ------------------------------
+    # Public API
 
     # Route a set of signals to arbitrary destinations.
     #
@@ -140,6 +149,10 @@ class Aca::Router
 
         edge.target
     end
+
+
+    # ------------------------------
+    # Internals
 
     protected
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -34,6 +34,7 @@ class Aca::Router
 
         check_compatability
 
+        # TODO: track active signal source at each node and expose as a hash
         self[:nodes] = signal_graph.map(&:id)
         self[:inputs] = signal_graph.sinks.map(&:id)
         self[:outputs] = signal_graph.sources.map(&:id)
@@ -165,6 +166,7 @@ class Aca::Router
         end
     end
 
+    # TODO: execute this on system device create / remove / stop / start etc
     def check_compatability
         invalid = Set.new
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -156,6 +156,9 @@ class Aca::Router
     # Find the shortest path between between two nodes and return a list of the
     # nodes which this passes through and their connecting edges.
     def route(source, sink)
+        source = source.to_sym
+        sink = sink.to_sym
+
         path = paths[sink]
 
         distance = path.distance_to[source]
@@ -406,6 +409,7 @@ class Aca::Router::SignalGraph
     end
 
     def [](id)
+        id = id.to_sym
         nodes[id]
     end
 
@@ -422,6 +426,7 @@ class Aca::Router::SignalGraph
     # to false to keep this O(1) rather than O(n). Using this flag at any other
     # time will result a corrupt structure.
     def delete(id, check_incoming_edges: true)
+        id = id.to_sym
         nodes.delete(id) { raise ArgumentError, "\"#{id}\" does not exist" }
         each { |node| node.edges.delete id } if check_incoming_edges
         self
@@ -440,6 +445,7 @@ class Aca::Router::SignalGraph
     end
 
     def include?(id)
+        id = id.to_sym
         nodes.key? id
     end
 
@@ -448,6 +454,7 @@ class Aca::Router::SignalGraph
     end
 
     def successors(id)
+        id = id.to_sym
         nodes[id].edges.keys
     end
 
@@ -460,12 +467,14 @@ class Aca::Router::SignalGraph
     end
 
     def incoming_edges(id)
+        id = id.to_sym
         each_with_object([]) do |node, edges|
             edges << node.edges[id] if node.edges.key? id
         end
     end
 
     def outgoing_edges(id)
+        id = id.to_sym
         nodes[id].edges.values
     end
 
@@ -478,6 +487,8 @@ class Aca::Router::SignalGraph
     end
 
     def dijkstra(id)
+        id = id.to_sym
+
         active = Containers::PriorityQueue.new { |x, y| (x <=> y) == -1 }
         distance_to = Hash.new { 1.0 / 0.0 }
         predecessor = {}

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -45,8 +45,6 @@ class Aca::Router
             logger.error 'invalid connection settings'
         end
 
-        check_compatability
-
         # TODO: track active signal source at each node and expose as a hash
         self[:nodes] = signal_graph.map(&:id)
         self[:inputs] = signal_graph.sinks.map(&:id)
@@ -186,29 +184,10 @@ class Aca::Router
         end
     end
 
-    # TODO: execute this on system device create / remove / stop / start etc
-    def check_compatability
-        invalid = Set.new
 
-        signal_graph.each do |node|
-            node.edges.each_pair do |_, edge|
-                mod = system[edge.device]
 
-                is_switch = edge.output.nil? && mod.respond_to?(:switch_to)
-                is_matrix = !edge.output.nil? && mod.respond_to?(:switch)
 
-                invalid << edge.device if mod.nil? || !(is_switch || is_matrix)
-            end
-        end
-
-        if invalid.empty?
-            true
         else
-            logger.warn do
-                modules = invalid.to_a.join ', '
-                "incompatible or non-existent modules in config: #{modules}"
-            end
-            false
         end
     end
 end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -25,7 +25,12 @@ class Aca::Router
 
         @path_cache = nil
 
-        @signal_graph = SignalGraph.from_map(setting(:connections) || {}).freeze
+        connections = setting(:connections) || {}
+        begin
+            @signal_graph = SignalGraph.from_map(connections).freeze
+        rescue
+            logger.error 'invalid connection settings'
+        end
 
         self[:nodes] = signal_graph.map(&:id)
         self[:inputs] = signal_graph.sinks.map(&:id)

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -45,9 +45,9 @@ class Aca::Router
     # Route a set of signals to arbitrary destinations.
     #
     # `signal_map`  is a hash of the structure `{ source: sink | [sinks] }`
-    # 'atomic'      may be used to throw an exception, prior to any device
-    #               interaction taking place if any of the routes are not
-    #               possible
+    # 'atomic'      may be used to prevent activation of any part of the signal
+    #               map, prior to any device interaction taking place, if any
+    #               of the routes are not possible
     # `force`       control if switch events should be forced, even when the
     #               associated device module is already reporting it's on the
     #               correct input
@@ -56,34 +56,29 @@ class Aca::Router
     # single source to a single destination, Ruby's implicit hash syntax can be
     # used to let you express it neatly as `connect source => sink`.
     def connect(signal_map, atomic: false, force: false)
-        edges = map_to_edges signal_map, strict: atomic
+        # Convert the signal map to a nested hash of routes
+        # { source => { dest => [edges] } }
+        edge_map = build_edge_map signal_map, atomic: atomic
 
-        edge_list = edges.values.reduce(&:|)
+        # Reduce the edge map to a set of edges
+        edges_to_connect = edge_map.reduce(Set.new) do |s, (_, routes)|
+            s | routes.values.reduce(&:|)
+        end
 
-        edge_list.select! { |e| needs_activation? e, ignore_status: force }
+        switch = activate_all edges_to_connect, atomic: atomic, force: force
 
-        edge_list, unroutable = edge_list.partition { |e| can_activate? e }
-        raise 'can not perform all routes' if unroutable.any? && atomic
+        switch.then do |success, failed|
+            if failed.empty?
+                logger.debug 'signal map fully activated'
+                edge_map.transform_values(&:keys)
 
-        interactions = edge_list.map { |e| activate e }
+            elsif success.empty?
+                thread.reject 'failed to activate, devices untouched'
 
-        thread.finally(interactions).then do |results|
-            failed = edge_list.zip(results).reject { |_, (_, success)| success }
-
-            edges_with_errors = unroutable
-            failed.each do |edge, (error, _)|
-                logger.warn "could not switch #{edge}: #{error}"
-                edges_with_errors << edge
-            end
-
-            if edges_with_errors.empty?
-                logger.debug 'all routes activated successfully'
-                signal_map
-            elsif atomic
-                thread.reject 'failed to activate all routes'
             else
-                signal_map.select do |source, _|
-                    (edges[source] & edges_with_errors).empty?
+                logger.warn 'signal map partially activated'
+                edge_map.transform_values do |routes|
+                    routes.select { |_, edges| success.superset? edges }.keys
                 end
             end
         end
@@ -198,57 +193,88 @@ class Aca::Router
         [nodes, edges]
     end
 
-    # Find the optimum combined paths required to route a single source to
-    # multiple sink devices.
-    def route_many(source, sinks, strict: false)
-        node_exists = proc do |id|
-            signal_graph.include?(id).tap do |exists|
-                unless exists
-                    message = "#{id} does not exist"
-                    raise ArgumentError, message if strict
-                    logger.warn message
-                end
-            end
-        end
-
-        nodes = Set.new
-        edges = Set.new
-
-        if node_exists[source]
-            Array(sinks).select(&node_exists).each do |sink|
-                n, e = route source, sink
-                nodes |= n
-                edges |= e
-            end
-        end
-
-        [nodes, edges]
-    end
-
-    # Given a signal map, convert it to a hash still keyed on source id's, but
-    # containing the edges within the graph to be utilised.
-    def map_to_edges(signal_map, strict: false)
-        nodes = {}
-        edges = {}
+    # Convert a signal map of the structure
+    #
+    #     source => [dest]
+    #
+    # to a nested hash of the structure
+    #
+    #     source => { dest => [edges] }
+    #
+    def build_edge_map(signal_map, atomic: false)
+        nodes_in_use = Set.new
+        edge_map = {}
 
         signal_map.each_pair do |source, sinks|
-            n, e = route_many source, sinks, strict: strict
-            nodes[source] = n
-            edges[source] = e
+            source = source.to_sym
+            sinks = Array(sinks).map(&:to_sym)
+
+            source_nodes = Set.new
+            edge_map[source] = {}
+
+            sinks.each do |sink|
+                begin
+                    nodes, edges = route source, sink
+
+                    if nodes_in_use.intersect? Set[nodes]
+                        partial_map = edge_map.transform_values(&:keys)
+                        route = "route from #{source} to #{sink}"
+                        raise "#{route} conflicts with routes in #{partial_map}"
+                    end
+
+                    source_nodes |= nodes
+                    edge_map[source][sink] = edges
+                rescue e
+                    # note `route` may also throw an exception (e.g. when there
+                    # is an invalid source / sink or unroutable path)
+                    raise if atomic
+                    logger.warn e.message
+                end
+            end
+
+            nodes_in_use |= source_nodes
         end
 
-        conflicts = nodes.size > 1 ? nodes.values.reduce(&:&) : Set.new
-        unless conflicts.empty?
-            sources = nodes.reject { |(_, n)| (n & conflicts).empty? }.keys
-            message = "routes for #{sources.join ', '} intersect"
-            raise message if strict
-            logger.warn message
-        end
-
-        edges
+        edge_map
     end
 
-    def needs_activation?(edge, ignore_status: false)
+    # Given a set of edges, activate them all and return a promise that will
+    # resolve following the completion of all device interactions.
+    #
+    # The returned promise contains the original edges, partitioned into
+    # success and failure sets.
+    def activate_all(edges, atomic: false, force: false)
+        success = Set.new
+        failed = Set.new
+
+        # Filter out any edges we can skip over
+        skippable = edges.reject { |e| needs_activation? e, force: force }
+        success  |= skippable
+        edges    -= skippable
+
+        # Remove anything that we know will fail up front
+        unroutable = edges.reject { |e| can_activate? e }
+        failed    |= unroutable
+        edges     -= unroutable
+
+        raise 'can not perform all routes' if atomic && unroutable.any?
+
+        interactions = edges.map { |e| activate e }
+
+        thread.finally(interactions).then do |results|
+            edges.zip(results).each do |edge, (result, resolved)|
+                if resolved
+                    success |= edge
+                else
+                    logger.warn "failed to switch #{edge}: #{result}"
+                    failed |= edge
+                end
+            end
+            [success, failed]
+        end
+    end
+
+    def needs_activation?(edge, force: false)
         mod = system[edge.device]
 
         fail_with = proc do |reason|
@@ -262,7 +288,7 @@ class Aca::Router
             if mod.nil? && single_source
 
         fail_with['already on correct input'] \
-            if edge.nx1? && mod[:input] == edge.input && !ignore_status
+            if edge.nx1? && mod[:input] == edge.input && !force
 
         fail_with['has an incompatible api, but only a single input defined'] \
             if edge.nx1? && !mod.respond_to?(:switch_to) && single_source

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -16,6 +16,11 @@ class Aca::Router
         devices and complex/layered switching infrastructure.
     DESC
 
+    default_settings(
+        # Nested hash of signal connectivity. See SignalGraph.from_map.
+        connections: {}
+    )
+
     def on_load
         on_update
     end
@@ -25,7 +30,15 @@ class Aca::Router
 
         @path_cache = nil
 
-        connections = setting(:connections) || {}
+        connections = setting(:connections).transform_values do |inputs|
+            # Read in numeric inputs as ints (as JSON based settings do not
+            # allow non-string keys)
+            if inputs.is_a? Hash
+                inputs.transform_keys! { |i| Integer(i) rescue i }
+            else
+                inputs
+            end
+        end
         begin
             @signal_graph = SignalGraph.from_map(connections).freeze
         rescue

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -471,7 +471,9 @@ class Aca::Router::SignalGraph
             when Array
                 (1..inputs.size).zip(inputs).to_h
             when Hash
-                inputs.transform_keys { |x| Integer(x) rescue x }
+                inputs.transform_keys do |key|
+                    key.to_s[/^\d+$/]&.to_i || key
+                end
             else
                 raise ArgumentError, 'inputs must be a Hash or Array'
             end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -251,6 +251,8 @@ class Aca::Router
             thread.reject "cannot interact with #{edge.device}. " \
                 'Module may be offline or incompatible.'
         end
+    rescue => e
+        thread.reject "error connecting #{edge.target} to #{edge.source}: #{e}"
     end
 end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -78,7 +78,9 @@ class Aca::Router
             else
                 logger.warn 'signal map partially activated'
                 edge_map.transform_values do |routes|
-                    routes.select { |_, edges| success.superset? edges }.keys
+                    routes.each_with_object([]) do |(output, edges), completed|
+                        completed << output if success.superset? Set.new(edges)
+                    end
                 end
             end
         end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -97,8 +97,15 @@ class Aca::Router
     # it. Similarly `on` maybe used to look up the input used by any other node
     # within the graph that would be used to show `source`.
     def input_for(source, on: nil)
-        sink = on || upstream(source)
-        _, edges = route source, sink
+        if on.nil?
+            edges = signal_graph.incoming_edges source
+            raise "no outputs from #{source}" if edges.empty?
+            raise "multiple outputs from #{source}, please specify a sink" \
+                unless edges.map(&:device).uniq.size == 1
+        else
+            _, edges = route source, on
+        end
+
         edges.last.input
     end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -219,7 +219,7 @@ class Aca::Router
         edges = {}
 
         signal_map.each_pair do |source, sinks|
-            n, e = route_many source, sinks, strict: atomic
+            n, e = route_many source, sinks, strict: strict
             nodes[source] = n
             edges[source] = e
         end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -62,7 +62,7 @@ class Aca::Router
 
         # Reduce the edge map to a set of edges
         edges_to_connect = edge_map.reduce(Set.new) do |s, (_, routes)|
-            s | routes.values.reduce(&:|)
+            s | routes.values.flatten
         end
 
         switch = activate_all edges_to_connect, atomic: atomic, force: force

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -385,7 +385,7 @@ class Aca::Router::SignalGraph
     end
 
     def incoming_edges(id)
-        reduce([]) do |edges, node|
+        each_with_object([]) do |node, edges|
             edges << node.edges[id] if node.edges.key? id
         end
     end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -180,12 +180,12 @@ class Aca::Router
 
         nodes = []
         edges = []
-        node = signal_graph[source]
+        node = source
         until node.nil?
             nodes.unshift node
-            predecessor = path.predecessor[node.id]
-            edges << predecessor.edges[node.id] unless predecessor.nil?
-            node = predecessor
+            prev = path.predecessor[node]
+            edges << signal_graph[prev].edges[node] unless prev.nil?
+            node = prev
         end
 
         logger.debug { edges.map(&:to_s).join ' then ' }
@@ -457,7 +457,7 @@ class Aca::Router::SignalGraph
     end
 
     def successors(id)
-        nodes[id].edges.keys.map { |x| nodes[x] }
+        nodes[id].edges.keys
     end
 
     def sources
@@ -492,16 +492,16 @@ class Aca::Router::SignalGraph
         predecessor = {}
 
         distance_to[id] = 0
-        active.push nodes[id], distance_to[id]
+        active.push id, distance_to[id]
 
         until active.empty?
             u = active.pop
-            successors(u.id).each do |v|
-                alt = distance_to[u.id] + 1
-                next unless alt < distance_to[v.id]
-                distance_to[v.id] = alt
-                predecessor[v.id] = u
-                active.push v, distance_to[v.id]
+            successors(u).each do |v|
+                alt = distance_to[u] + 1
+                next unless alt < distance_to[v]
+                distance_to[v] = alt
+                predecessor[v] = u
+                active.push v, distance_to[v]
             end
         end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -257,17 +257,19 @@ end
 class Aca::Router::SignalGraph
     Paths = Struct.new :distance_to, :predecessor
 
-    Edge = Struct.new :source, :target, :device, :input, :output do
-        def device=(device)
-            super(device.try(:to_sym) || device)
-        end
+    class Edge
+        attr_reader :source, :target, :device, :input, :output
 
-        def input=(input)
-            super(input.try(:to_sym) || input)
-        end
+        Meta = Struct.new(:device, :input, :output)
 
-        def output=(output)
-            super(output.try(:to_sym) || output)
+        def initialize(source, target, &blk)
+            @source = source
+            @target = target
+
+            meta = Meta.new.tap(&blk)
+            @device = meta.device&.to_sym
+            @input  = meta.input.try(:to_sym) || meta.input
+            @output = meta.output.try(:to_sym) || meta.output
         end
 
         def to_s
@@ -347,7 +349,7 @@ class Aca::Router::SignalGraph
     end
 
     def join(source, target, &block)
-        datum = Edge.new(source, target).tap(&block)
+        datum = Edge.new(source, target, &block)
         nodes[source].join target, datum
         self
     end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -230,7 +230,7 @@ class Aca::Router
         mod = system[edge.device]
 
         fail_with = proc do |reason|
-            logger.warn "#{edge.device} #{reason} - can not switch #{edge}"
+            logger.warn "mod #{edge.device} #{reason} - can not switch #{edge}"
             return false
         end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -77,6 +77,13 @@ class Aca::Router
         end
     end
 
+    # Lookup the name of the input on a sink node that would be used to connect
+    # a source to it.
+    def input_for(source, sink)
+        _, edges = route source, sink
+        edges.last.input
+    end
+
     protected
 
     def signal_graph

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -69,7 +69,7 @@ class Aca::Router
 
         switch.then do |success, failed|
             if failed.empty?
-                logger.debug 'signal map fully activated'
+                logger.debug 'signal map activated'
                 edge_map.transform_values(&:keys)
 
             elsif success.empty?
@@ -228,7 +228,7 @@ class Aca::Router
                     # note `route` may also throw an exception (e.g. when there
                     # is an invalid source / sink or unroutable path)
                     raise if atomic
-                    logger.warn e.message
+                    logger.error e.message
                 end
             end
 

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -23,7 +23,7 @@ class Aca::Router
     def on_update
         logger.debug 'building graph from signal map'
 
-        @route_cache = nil
+        @path_cache = nil
 
         @signal_graph = SignalGraph.from_map(setting(:connections) || {}).freeze
 
@@ -66,7 +66,7 @@ class Aca::Router
     end
 
     def paths
-        @route_cache ||= Hash.new do |hash, node|
+        @path_cache ||= Hash.new do |hash, node|
             hash[node] = signal_graph.dijkstra node
         end
     end
@@ -79,21 +79,22 @@ class Aca::Router
 
     # Find the shortest path between a source and target node and return the
     # list of nodes which form it.
-    def route(source, target)
-        path = paths[target]
+    def route(source, sink)
+        path = paths[sink]
 
         distance = path.distance_to[source]
-        raise "no route from #{source} to #{target}" if distance.infinite?
+        raise "no route from #{source} to #{sink}" if distance.infinite?
 
         logger.debug do
-            "found route from #{source} to #{target} in #{distance} hops"
+            "found route from #{source} to #{sink} in #{distance} hops"
         end
 
         nodes = []
-        next_node = signal_graph[source]
-        until next_node.nil?
-            nodes << next_node
-            next_node = path.predecessor[next_node.id]
+        node = signal_graph[source]
+        until node.nil?
+            nodes << node
+            predecessor = path.predecessor[node.id]
+            node = predecessor
         end
         nodes
     end

--- a/modules/aca/router.rb
+++ b/modules/aca/router.rb
@@ -264,10 +264,10 @@ class Aca::Router
         thread.finally(interactions).then do |results|
             edges.zip(results).each do |edge, (result, resolved)|
                 if resolved
-                    success |= edge
+                    success << edge
                 else
                     logger.warn "failed to switch #{edge}: #{result}"
-                    failed |= edge
+                    failed << edge
                 end
             end
             [success, failed]

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -107,11 +107,11 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
     mods = SignalGraph.extract_mods!(normalised_map)
     expect(mods).to eq(
-        Left_LCD:   :Display_1,
-        Right_LCD:  :Display_2,
-        Switcher_1: :Switcher_1,
-        SubSwitchA: :Switcher_2,
-        SubSwitchB: :Switcher_2
+        'Left_LCD'   => 'Display_1',
+        'Right_LCD'  => 'Display_2',
+        'Switcher_1' => 'Switcher_1',
+        'SubSwitchA' => 'Switcher_2',
+        'SubSwitchB' => 'Switcher_2'
     )
     expect(normalised_map).to eq(
         Left_LCD: {

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -161,8 +161,6 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
     # -------------------------------------------------------------------------
     section 'Routing'
 
-    exec(:load_from_map, signal_map)
-
     exec(:route, :a, :Left_LCD)
     nodes, edges = result
     expect(nodes.map(&:id)).to contain_exactly(:a, :Switcher_1__1, :Left_LCD)
@@ -181,6 +179,15 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
     expect { exec(:route, :e, :Left_LCD) }.to \
         raise_error('no route from e to Left_LCD')
 
+    # -------------------------------------------------------------------------
+    section 'Edge maps'
+
+    exec(:build_edge_map, a: :Left_LCD, b: :Right_LCD)
+    edge_map = result
+    expect(edge_map.keys).to contain_exactly(:a, :b)
+    expect(edge_map[:a]).to be_a(Hash)
+    expect(edge_map[:a][:Left_LCD]).to be_a(Array)
+
 
     # -------------------------------------------------------------------------
     section 'Graph queries'
@@ -190,4 +197,7 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
     exec(:input_for, :a, on: :Left_LCD)
     expect(result).to be(:hdmi)
+
+    exec(:upstream, :g)
+    expect(result).to be(:Right_LCD)
 end

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+Orchestrator::Testing.mock_device 'Aca::Router' do
+    def section(message)
+        puts "\n\n#{'-' * 80}"
+        puts message
+        puts "\n"
+    end
+
+    # -------------------------------------------------------------------------
+    section 'Internal graph tests'
+
+    graph = Aca::Router::SignalGraph.new
+
+    # Node insertion
+    graph << :test_node
+    expect(graph).to include(:test_node)
+
+    # Node access
+    expect(graph[:test_node]).to be_a(Aca::Router::SignalGraph::Node)
+    expect { graph[:does_not_exist] }.to raise_error(ArgumentError)
+
+    # Node deletion
+    graph.delete :test_node
+    expect(graph).not_to include(:test_node)
+
+    # Edge creation
+    graph << :display
+    graph << :laptop
+    graph.join(:display, :laptop) do |edge|
+        edge.device = :Display_1
+        edge.input  = :hdmi
+    end
+    expect(graph.successors(:display)).to include(graph[:laptop])
+
+    # Graph structural inspection
+    # note: signal flow is inverted from graph directivity
+    expect(graph.indegree(:display)).to be(0)
+    expect(graph.indegree(:laptop)).to be(1)
+    expect(graph.outdegree(:display)).to be(1)
+    expect(graph.outdegree(:laptop)).to be(0)
+    expect(graph.sources.map(&:id)).to include(:display)
+    expect(graph.sinks.map(&:id)).to include(:laptop)
+
+    # Edge inspection
+    edge = graph[:display].edges[:laptop]
+    expect(edge.device).to be(:Display_1)
+    expect(edge.input).to be(:hdmi)
+    expect(edge).to be_nx1
+    expect(edge).not_to be_nxn
+
+    # Creation from a signal map
+    graph = Aca::Router::SignalGraph.from_map(
+        Display_1: {
+            hdmi: :Switcher_1__1
+        },
+        Display_2: {
+            hdmi: :Switcher_1__2
+        },
+        Display_3: {
+            display_port: :Switcher_2
+        },
+        Switcher_1: [:Laptop_1, :Laptop_2, :Switcher_2],
+        Switcher_2: {
+            usbc: :Laptop_3,
+            wireless: :Wireless
+        }
+    )
+
+    expect(graph.sources.map(&:id)).to \
+        contain_exactly(:Display_1, :Display_2, :Display_3)
+
+    expect(graph.sinks.map(&:id)).to \
+        contain_exactly(:Laptop_1, :Laptop_2, :Laptop_3, :Wireless)
+
+    # Path finding
+    routes = graph.sources.map(&:id).map { |id| [id, graph.dijkstra(id)] }.to_h
+    expect(routes[:Display_1].distance_to[:Laptop_1]).to be(2)
+    expect(routes[:Display_1].distance_to[:Laptop_3]).to be(3)
+    expect(routes[:Display_3].distance_to[:Laptop_1]).to be_infinite
+    expect(routes[:Display_3].distance_to[:Laptop_3]).to be(2)
+end

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -155,6 +155,10 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
 
     # -------------------------------------------------------------------------
+
+    exec(:load_from_map, signal_map)
+
+    # -------------------------------------------------------------------------
     section 'Routing'
 
     exec(:load_from_map, signal_map)
@@ -176,4 +180,14 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
     expect { exec(:route, :e, :Left_LCD) }.to \
         raise_error('no route from e to Left_LCD')
+
+
+    # -------------------------------------------------------------------------
+    section 'Graph queries'
+
+    exec(:input_for, :a)
+    expect(result).to be(1)
+
+    exec(:input_for, :a, on: :Left_LCD)
+    expect(result).to be(:hdmi)
 end

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -155,19 +155,24 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
 
     # -------------------------------------------------------------------------
-    section 'Module methods'
+    section 'Routing'
 
     exec(:load_from_map, signal_map)
 
     exec(:route, :a, :Left_LCD)
-    nodes, = result
-    nodes.map!(&:id)
-    expect(nodes).to contain_exactly(:Left_LCD, :Switcher_1__1, :a)
+    nodes, edges = result
+    expect(nodes.map(&:id)).to contain_exactly(:a, :Switcher_1__1, :Left_LCD)
+    expect(edges.first).to be_nxn
+    expect(edges.first.device).to be(:Switcher_1)
+    expect(edges.first.input).to be(1)
+    expect(edges.first.output).to be(1)
+    expect(edges.second).to be_nx1
+    expect(edges.second.device).to be(:Display_1)
+    expect(edges.second.input).to be(:hdmi)
 
     exec(:route, :c, :Left_LCD)
     nodes, = result
-    nodes.map!(&:id)
-    expect(nodes).to contain_exactly(:Left_LCD, :SubSwitchA__1, :c)
+    expect(nodes.map(&:id)).to contain_exactly(:c, :SubSwitchA__1, :Left_LCD)
 
     expect { exec(:route, :e, :Left_LCD) }.to \
         raise_error('no route from e to Left_LCD')

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -83,13 +83,13 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
     normalised_map = SignalGraph.normalise(signal_map)
     expect(normalised_map).to eq(
         'Display_1 as Left_LCD' => {
-            'hdmi'  => 'Switcher_1__1',
-            'hdmi2' => 'SubSwitchA__1'
+            hdmi: 'Switcher_1__1',
+            hdmi2: 'SubSwitchA__1'
         },
         'Display_2 as Right_LCD' => {
-            'hdmi'  => 'Switcher_1__2',
-            'hdmi2' => 'SubSwitchB__2',
-            'display_port' => 'g'
+            hdmi: 'Switcher_1__2',
+            hdmi2: 'SubSwitchB__2',
+            display_port: 'g'
         },
         'Switcher_1' => {
             1 => 'a',
@@ -107,31 +107,31 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
     mods = SignalGraph.extract_mods!(normalised_map)
     expect(mods).to eq(
-        'Left_LCD'   => :Display_1,
-        'Right_LCD'  => :Display_2,
-        'Switcher_1' => :Switcher_1,
-        'SubSwitchA' => :Switcher_2,
-        'SubSwitchB' => :Switcher_2
+        Left_LCD:   :Display_1,
+        Right_LCD:  :Display_2,
+        Switcher_1: :Switcher_1,
+        SubSwitchA: :Switcher_2,
+        SubSwitchB: :Switcher_2
     )
     expect(normalised_map).to eq(
-        'Left_LCD' => {
-            'hdmi'  => 'Switcher_1__1',
-            'hdmi2' => 'SubSwitchA__1'
+        Left_LCD: {
+            hdmi: 'Switcher_1__1',
+            hdmi2: 'SubSwitchA__1'
         },
-        'Right_LCD' => {
-            'hdmi'  => 'Switcher_1__2',
-            'hdmi2' => 'SubSwitchB__2',
-            'display_port' => 'g'
+        Right_LCD: {
+            hdmi: 'Switcher_1__2',
+            hdmi2: 'SubSwitchB__2',
+            display_port: 'g'
         },
-        'Switcher_1' => {
+        Switcher_1: {
             1 => 'a',
             2 => 'b'
         },
-        'SubSwitchA' => {
+        SubSwitchA: {
             1 => 'c',
             2 => 'd'
         },
-        'SubSwitchB' => {
+        SubSwitchB: {
             3 => 'e',
             4 => 'f'
         }

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -35,7 +35,7 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
         edge.device = :Display_1
         edge.input  = :hdmi
     end
-    expect(graph.successors(:display)).to include(graph[:laptop])
+    expect(graph.successors(:display)).to include(:laptop)
 
     # Graph structural inspection
     # note: signal flow is inverted from graph directivity
@@ -163,7 +163,7 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
     exec(:route, :a, :Left_LCD)
     nodes, edges = result
-    expect(nodes.map(&:id)).to contain_exactly(:a, :Switcher_1__1, :Left_LCD)
+    expect(nodes).to contain_exactly(:a, :Switcher_1__1, :Left_LCD)
     expect(edges.first).to be_nxn
     expect(edges.first.device).to be(:Switcher_1)
     expect(edges.first.input).to be(1)
@@ -174,7 +174,7 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
     exec(:route, :c, :Left_LCD)
     nodes, = result
-    expect(nodes.map(&:id)).to contain_exactly(:c, :SubSwitchA__1, :Left_LCD)
+    expect(nodes).to contain_exactly(:c, :SubSwitchA__1, :Left_LCD)
 
     expect { exec(:route, :e, :Left_LCD) }.to \
         raise_error('no route from e to Left_LCD')

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 Orchestrator::Testing.mock_device 'Aca::Router' do
     def section(message)
         puts "\n\n#{'-' * 80}"
@@ -7,17 +9,19 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
         puts "\n"
     end
 
-    # -------------------------------------------------------------------------
-    section 'Internal graph tests'
+    SignalGraph = Aca::Router::SignalGraph
 
-    graph = Aca::Router::SignalGraph.new
+    # -------------------------------------------------------------------------
+    section 'Internal graph structure'
+
+    graph = SignalGraph.new
 
     # Node insertion
     graph << :test_node
     expect(graph).to include(:test_node)
 
     # Node access
-    expect(graph[:test_node]).to be_a(Aca::Router::SignalGraph::Node)
+    expect(graph[:test_node]).to be_a(SignalGraph::Node)
     expect { graph[:does_not_exist] }.to raise_error(ArgumentError)
 
     # Node deletion
@@ -49,34 +53,122 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
     expect(edge).to be_nx1
     expect(edge).not_to be_nxn
 
-    # Creation from a signal map
-    graph = Aca::Router::SignalGraph.from_map(
-        Display_1: {
-            hdmi: :Switcher_1__1
+
+    # -------------------------------------------------------------------------
+    section 'Parse from signal map'
+
+    signal_map = JSON.parse <<-JSON
+        {
+            "Display_1 as Left_LCD": {
+                "hdmi": "Switcher_1__1",
+                "hdmi2": "SubSwitchA__1"
+            },
+            "Display_2 as Right_LCD": {
+                "hdmi": "Switcher_1__2",
+                "hdmi2": "SubSwitchB__2",
+                "display_port": "g"
+            },
+            "Switcher_1": ["a", "b"],
+            "Switcher_2 as SubSwitchA": {
+                "1": "c",
+                "2": "d"
+            },
+            "Switcher_2 as SubSwitchB": {
+                "3": "e",
+                "4": "f"
+            }
+        }
+    JSON
+
+    normalised_map = SignalGraph.normalise(signal_map)
+    expect(normalised_map).to eq(
+        'Display_1 as Left_LCD' => {
+            'hdmi'  => 'Switcher_1__1',
+            'hdmi2' => 'SubSwitchA__1'
         },
-        Display_2: {
-            hdmi: :Switcher_1__2
+        'Display_2 as Right_LCD' => {
+            'hdmi'  => 'Switcher_1__2',
+            'hdmi2' => 'SubSwitchB__2',
+            'display_port' => 'g'
         },
-        Display_3: {
-            display_port: :Switcher_2
+        'Switcher_1' => {
+            1 => 'a',
+            2 => 'b'
         },
-        Switcher_1: [:Laptop_1, :Laptop_2, :Switcher_2],
-        Switcher_2: {
-            usbc: :Laptop_3,
-            wireless: :Wireless
+        'Switcher_2 as SubSwitchA' => {
+            1 => 'c',
+            2 => 'd'
+        },
+        'Switcher_2 as SubSwitchB' => {
+            3 => 'e',
+            4 => 'f'
         }
     )
 
-    expect(graph.sources.map(&:id)).to \
-        contain_exactly(:Display_1, :Display_2, :Display_3)
+    mods = SignalGraph.extract_mods!(normalised_map)
+    expect(mods).to eq(
+        'Left_LCD'   => :Display_1,
+        'Right_LCD'  => :Display_2,
+        'Switcher_1' => :Switcher_1,
+        'SubSwitchA' => :Switcher_2,
+        'SubSwitchB' => :Switcher_2
+    )
+    expect(normalised_map).to eq(
+        'Left_LCD' => {
+            'hdmi'  => 'Switcher_1__1',
+            'hdmi2' => 'SubSwitchA__1'
+        },
+        'Right_LCD' => {
+            'hdmi'  => 'Switcher_1__2',
+            'hdmi2' => 'SubSwitchB__2',
+            'display_port' => 'g'
+        },
+        'Switcher_1' => {
+            1 => 'a',
+            2 => 'b'
+        },
+        'SubSwitchA' => {
+            1 => 'c',
+            2 => 'd'
+        },
+        'SubSwitchB' => {
+            3 => 'e',
+            4 => 'f'
+        }
+    )
 
-    expect(graph.sinks.map(&:id)).to \
-        contain_exactly(:Laptop_1, :Laptop_2, :Laptop_3, :Wireless)
+    graph = SignalGraph.from_map(signal_map)
 
-    # Path finding
+    expect(graph.sources.map(&:id)).to contain_exactly(:Left_LCD, :Right_LCD)
+
+    expect(graph.sinks.map(&:id)).to contain_exactly(*(:a..:g).to_a)
+
     routes = graph.sources.map(&:id).map { |id| [id, graph.dijkstra(id)] }.to_h
-    expect(routes[:Display_1].distance_to[:Laptop_1]).to be(2)
-    expect(routes[:Display_1].distance_to[:Laptop_3]).to be(3)
-    expect(routes[:Display_3].distance_to[:Laptop_1]).to be_infinite
-    expect(routes[:Display_3].distance_to[:Laptop_3]).to be(2)
+    expect(routes[:Left_LCD].distance_to[:a]).to be(2)
+    expect(routes[:Left_LCD].distance_to[:c]).to be(2)
+    expect(routes[:Left_LCD].distance_to[:e]).to be_infinite
+    expect(routes[:Left_LCD].distance_to[:g]).to be_infinite
+    expect(routes[:Right_LCD].distance_to[:g]).to be(1)
+    expect(routes[:Right_LCD].distance_to[:a]).to be(2)
+    expect(routes[:Right_LCD].distance_to[:g]).to be(1)
+    expect(routes[:Right_LCD].distance_to[:c]).to be_infinite
+
+
+    # -------------------------------------------------------------------------
+    section 'Module methods'
+
+    exec(:load_from_map, signal_map)
+
+    exec(:route, :a, :Left_LCD)
+    nodes, = result
+    nodes.map!(&:id)
+    expect(nodes).to contain_exactly(:Left_LCD, :Switcher_1__1, :a)
+
+    exec(:route, :c, :Left_LCD)
+    nodes, = result
+    nodes.map!(&:id)
+    expect(nodes).to contain_exactly(:Left_LCD, :SubSwitchA__1, :c)
+
+    expect { exec(:route, :e, :Left_LCD) }.to \
+        raise_error('no route from e to Left_LCD')
 end

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -198,6 +198,9 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
     exec(:input_for, :a, on: :Left_LCD)
     expect(result).to be(:hdmi)
 
-    exec(:upstream, :g)
-    expect(result).to be(:Right_LCD)
+    exec(:device_for, :g)
+    expect(result).to be(:Display_2)
+
+    exec(:devices_between, :c, :Left_LCD)
+    expect(result).to contain_exactly(:Switcher_2, :Display_1)
 end

--- a/modules/aca/router_spec.rb
+++ b/modules/aca/router_spec.rb
@@ -43,8 +43,8 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
     expect(graph.indegree(:laptop)).to be(1)
     expect(graph.outdegree(:display)).to be(1)
     expect(graph.outdegree(:laptop)).to be(0)
-    expect(graph.sources.map(&:id)).to include(:display)
-    expect(graph.sinks.map(&:id)).to include(:laptop)
+    expect(graph.sources).to include(:display)
+    expect(graph.sinks).to include(:laptop)
 
     # Edge inspection
     edge = graph[:display].edges[:laptop]
@@ -139,11 +139,11 @@ Orchestrator::Testing.mock_device 'Aca::Router' do
 
     graph = SignalGraph.from_map(signal_map)
 
-    expect(graph.sources.map(&:id)).to contain_exactly(:Left_LCD, :Right_LCD)
+    expect(graph.sources).to contain_exactly(:Left_LCD, :Right_LCD)
 
-    expect(graph.sinks.map(&:id)).to contain_exactly(*(:a..:g).to_a)
+    expect(graph.sinks).to contain_exactly(*(:a..:g).to_a)
 
-    routes = graph.sources.map(&:id).map { |id| [id, graph.dijkstra(id)] }.to_h
+    routes = graph.sources.map { |id| [id, graph.dijkstra(id)] }.to_h
     expect(routes[:Left_LCD].distance_to[:a]).to be(2)
     expect(routes[:Left_LCD].distance_to[:c]).to be(2)
     expect(routes[:Left_LCD].distance_to[:e]).to be_infinite


### PR DESCRIPTION
# Description

Signal router logic module for handling signal distribution across complex switching infrastructure.

Provides a means to define physical connectivity within a system once, and then abstract this from other system logic. Other components may then simply connect signal sources to sinks (displays etc).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New device driver
- [ ] New service driver
- [x] New logic driver
- [ ] Driver update (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

## Configuration

To define connectivity, declare a setting `connections` with a hash of the structure

    { device: { input_name: source } }

or

    { device: [source] }

These to formats may be combined. When inputs are specified as an array, 1-based indices will be used.

Sources which exist on matrix switchers are defined as `device__output`.

For example, a system containing two displays and two laptop inputs, all connected via 2x2 matrix switcher would be defined as:

    {
        "Display_1": {
            "hdmi": "Switcher_1__1"
        },
        "Display_2": {
            "hdmi": "Switcher_1__2"
        },
        "Switcher_1": ["Laptop_1", "Laptop_2"]
    }

Device keys should relate to module id's for control. These may also be aliased by defining them as as `"mod as device"`. This can be used to provide better readability (e.g. "Display_1 as Left_LCD") or to segment them so that only specific routes are allowed. This approach enables devices such as centralised matrix switchers split into multiple virtual switchers that only have access to a subset of the inputs.

Signal networks are parsed into a graph which is then used to perform shortest path searches to perform all inter-device routing. Paths are cached to provide efficient routing following initial discovery.

## API

### `connect(signal_map, atomic: false, force: false)`

Connect any signal source(s) to any signal sink(s).

`signal_map` is a HashMap of the structure `{ source: sink | [sinks] }`.

If a route is not possible, a warning will be logged. The `atomic` parameter may be used to cause an exception to be raised instead. This will occur prior to any device interaction taking place, ensuring that a signal map recall can take place via an 'all or nothing' strategy.

If a device is reporting it is already on the correct input, no interaction will take place. `force` can be used to override this behaviour.

A `Libuv::Q::Promise` containing the applied signal map is returned following completion of all device interactions. If some routes were unable to be applied, a subset of the original map (containing the applied component) is returned.
