### PR TITLE
Cisco Touch 10

### DIFF
--- a/modules/cisco/collaboration_endpoint/external_source.rb
+++ b/modules/cisco/collaboration_endpoint/external_source.rb
@@ -13,7 +13,7 @@ module Cisco::CollaborationEndpoint::ExternalSource
             super
             register_feedback \
                 '/Event/UserInterface/Presentation/ExternalSource' do |action|
-                source = action.dig 'Selected', 'SourceIdentifier'
+                source = action.dig :Selected, :SourceIdentifier
                 unless source.nil?
                     self[:external_source] = source
                     signal_status(:external_source)

--- a/modules/cisco/collaboration_endpoint/room_kit.rb
+++ b/modules/cisco/collaboration_endpoint/room_kit.rb
@@ -32,6 +32,7 @@ class Cisco::CollaborationEndpoint::RoomKit < Cisco::CollaborationEndpoint::Room
         end
 
         self[:calls] = {}
+        self[:in_call] = false
         register_feedback '/Status/Call' do |call|
             calls = self[:calls].deep_merge call
             calls.reject! do |_, props|

--- a/modules/cisco/collaboration_endpoint/room_kit.rb
+++ b/modules/cisco/collaboration_endpoint/room_kit.rb
@@ -38,6 +38,7 @@ class Cisco::CollaborationEndpoint::RoomKit < Cisco::CollaborationEndpoint::Room
                 props[:status] == :Idle || props.include?(:ghost)
             end
             self[:calls] = calls
+            self[:in_call] = calls.present?
         end
     end
 

--- a/modules/cisco/collaboration_endpoint/room_kit.rb
+++ b/modules/cisco/collaboration_endpoint/room_kit.rb
@@ -13,7 +13,7 @@ class Cisco::CollaborationEndpoint::RoomKit < Cisco::CollaborationEndpoint::Room
     description <<~DESC
         Control of Cisco RoomKit devices.
 
-        API access requires a local user with the 'integrator' role to be
+        API access requires a local user with the 'admin' role to be
         created on the codec.
     DESC
 

--- a/modules/cisco/collaboration_endpoint/room_kit.rb
+++ b/modules/cisco/collaboration_endpoint/room_kit.rb
@@ -82,6 +82,11 @@ class Cisco::CollaborationEndpoint::RoomKit < Cisco::CollaborationEndpoint::Room
     command 'Call Accept' => :call_accept, CallId_: Integer
     command 'Call Reject' => :call_reject, CallId_: Integer
     command 'Call Disconnect' => :hangup, CallId_: Integer
+
+    command 'Call DTMFSend' => :dtmf_send,
+            DTMFString: String,
+            CallId_: (0..65534)
+
     command 'Dial' => :dial,
             Number:  String,
             Protocol_: [:H320, :H323, :Sip, :Spark],

--- a/modules/cisco/collaboration_endpoint/room_os.rb
+++ b/modules/cisco/collaboration_endpoint/room_os.rb
@@ -107,10 +107,10 @@ class Cisco::CollaborationEndpoint::RoomOs
     # Execute an xCommand on the device.
     #
     # @param command [String] the command to execute
-    # @param args [Hash] the command arguments
+    # @param kwargs [Hash] the command arguments
     # @return [::Libuv::Q::Promise] resolves when the command completes
-    def xcommand(command, args = {})
-        send_xcommand command, args
+    def xcommand(command, kwargs = {})
+        send_xcommand command, kwargs
     end
 
     # Push a configuration settings to the device.
@@ -155,17 +155,17 @@ class Cisco::CollaborationEndpoint::RoomOs
     # to protect access to #xcommand and still refer the gruntwork here.
     #
     # @param comand [String] the xAPI command to execute
-    # @param args [Hash] the command keyword args
+    # @param kwargs [Hash] the command keyword args
     # @return [::Libuv::Q::Promise] that will resolve when execution is complete
-    def send_xcommand(command, args = {})
-        request = Action.xcommand command, args
+    def send_xcommand(command, kwargs = {})
+        request = Action.xcommand command, kwargs
 
         # Multi-arg commands (external source registration, UI interaction etc)
         # all need to be properly queued and sent without be overriden. In
         # these cases, leave the outgoing commands unnamed.
         opts = {}
-        opts[:name] = command if args.empty?
-        opts[:name] = "#{command} #{args.keys.first}" if args.size == 1
+        opts[:name] = command if kwargs.empty?
+        opts[:name] = "#{command} #{kwargs.keys.first}" if kwargs.size == 1
 
         do_send request, **opts do |response|
             # The result keys are a little odd: they're a concatenation of the

--- a/modules/cisco/collaboration_endpoint/room_os_spec.rb
+++ b/modules/cisco/collaboration_endpoint/room_os_spec.rb
@@ -195,7 +195,7 @@ Orchestrator::Testing.mock_device 'Cisco::CollaborationEndpoint::RoomOs',
             }
         JSON
     )
-    expect(status[:configuration].dig(:audio, :input, :microphone, 1, :mode)).to be true
+    expect(status[:configuration].dig(:Audio, :Input, :Microphone, 1, :Mode)).to be true
 
     # -------------------------------------------------------------------------
     section 'Base comms (protected methods - ignore the access warnings)'
@@ -342,7 +342,7 @@ Orchestrator::Testing.mock_device 'Cisco::CollaborationEndpoint::RoomOs',
                 }
             JSON
         )
-    expect(result).to be :success
+    expect(result).to eq status: 'OK'
 
     # Command with arguments
     exec(:xcommand, 'Video Input SetMainVideoSource', ConnectorId: 1, Layout: :PIP)
@@ -359,7 +359,7 @@ Orchestrator::Testing.mock_device 'Cisco::CollaborationEndpoint::RoomOs',
                 }
             JSON
         )
-    expect(result).to be :success
+    expect(result).to eq status: 'OK'
 
     # Return device argument errors
     exec(:xcommand, 'Video Input SetMainVideoSource', ConnectorId: 1, SourceId: 1)
@@ -448,7 +448,7 @@ Orchestrator::Testing.mock_device 'Cisco::CollaborationEndpoint::RoomOs',
         )
     expect(result).to be :success
 
-    # Multuple settings with failure with return a promise that rejects
+    # Multiple settings with failure with return a command failure
     exec(:xconfiguration, 'Video Input Connector 1', InputSourceType: :Camera, Foo: 'Bar', Quality: :Motion)
         .should_send("xConfiguration Video Input Connector 1 InputSourceType: Camera | resultId=\"#{id_peek}\"\n")
         .responds(
@@ -485,10 +485,7 @@ Orchestrator::Testing.mock_device 'Cisco::CollaborationEndpoint::RoomOs',
                 }
             JSON
         )
-    result.tap do |last_result|
-        expect(last_result.resolved?).to be true
-        expect { last_result.value }.to raise_error(CoroutineRejection)
-    end
+    expect { result }.to raise_error(Orchestrator::Error::CommandFailure)
 
 
     # -------------------------------------------------------------------------
@@ -564,5 +561,5 @@ Orchestrator::Testing.mock_device 'Cisco::CollaborationEndpoint::RoomOs',
                 }
             JSON
         )
-    expect(result['SystemTime']).to eq '2017-11-27T15:14:25+1000'
+    expect(result).to eq SystemTime: '2017-11-27T15:14:25+1000'
 end

--- a/modules/cisco/collaboration_endpoint/room_os_spec.rb
+++ b/modules/cisco/collaboration_endpoint/room_os_spec.rb
@@ -404,6 +404,30 @@ Orchestrator::Testing.mock_device 'Cisco::CollaborationEndpoint::RoomOs',
         )
     expect { result }.to raise_error(Orchestrator::Error::CommandFailure)
 
+    # Multiline commands
+    exec(:xcommand, 'SystemUnit SignInBanner Set', "Hello\nWorld!")
+        .should_send(
+            <<~COMMAND
+                xCommand SystemUnit SignInBanner Set | resultId=\"#{id_peek}\"
+                Hello
+                World!
+                .
+            COMMAND
+        )
+        .responds(
+            <<~JSON
+                {
+                    "CommandResponse":{
+                        "SignInBannerSetResult":{
+                            "status":"OK"
+                        }
+                    },
+                    "ResultId": \"#{id_pop}\"
+                }
+            JSON
+        )
+    expect(result).to eq status: 'OK'
+
 
     # -------------------------------------------------------------------------
     section 'Configuration'

--- a/modules/cisco/collaboration_endpoint/sx20.rb
+++ b/modules/cisco/collaboration_endpoint/sx20.rb
@@ -77,6 +77,11 @@ class Cisco::CollaborationEndpoint::Sx20 < Cisco::CollaborationEndpoint::RoomOs
     command 'Call Accept' => :call_accept, CallId_: Integer
     command 'Call Reject' => :call_reject, CallId_: Integer
     command 'Call Disconnect' => :hangup, CallId_: Integer
+
+    command 'Call DTMFSend' => :dtmf_send,
+            DTMFString: String,
+            CallId_: (0..65534)
+
     command 'Dial' => :dial,
             Number:  String,
             Protocol_: [:H320, :H323, :Sip, :Spark],

--- a/modules/cisco/collaboration_endpoint/sx20.rb
+++ b/modules/cisco/collaboration_endpoint/sx20.rb
@@ -13,7 +13,7 @@ class Cisco::CollaborationEndpoint::Sx20 < Cisco::CollaborationEndpoint::RoomOs
     description <<~DESC
         Control of Cisco SX20 devices.
 
-        API access requires a local user with the 'integrator' role to be
+        API access requires a local user with the 'admin' role to be
         created on the codec.
     DESC
 

--- a/modules/cisco/collaboration_endpoint/sx80.rb
+++ b/modules/cisco/collaboration_endpoint/sx80.rb
@@ -32,6 +32,7 @@ class Cisco::CollaborationEndpoint::Sx80 < Cisco::CollaborationEndpoint::RoomOs
         end
 
         self[:calls] = {}
+        self[:in_call] = false
         register_feedback '/Status/Call' do |call|
             calls = self[:calls].deep_merge call
             calls.reject! do |_, props|

--- a/modules/cisco/collaboration_endpoint/sx80.rb
+++ b/modules/cisco/collaboration_endpoint/sx80.rb
@@ -13,7 +13,7 @@ class Cisco::CollaborationEndpoint::Sx80 < Cisco::CollaborationEndpoint::RoomOs
     description <<~DESC
         Control of Cisco SX80 devices.
 
-        API access requires a local user with the 'integrator' role to be
+        API access requires a local user with the 'admin' role to be
         created on the codec.
     DESC
 

--- a/modules/cisco/collaboration_endpoint/sx80.rb
+++ b/modules/cisco/collaboration_endpoint/sx80.rb
@@ -38,6 +38,7 @@ class Cisco::CollaborationEndpoint::Sx80 < Cisco::CollaborationEndpoint::RoomOs
                 props[:status] == :Idle || props.include?(:ghost)
             end
             self[:calls] = calls
+            self[:in_call] = calls.present?
         end
     end
 

--- a/modules/cisco/collaboration_endpoint/sx80.rb
+++ b/modules/cisco/collaboration_endpoint/sx80.rb
@@ -84,9 +84,9 @@ class Cisco::CollaborationEndpoint::Sx80 < Cisco::CollaborationEndpoint::RoomOs
     command 'Call Disconnect' => :hangup, CallId_: Integer
 
     command 'Call DTMFSend' => :dtmf_send,
-           CallId: (0..65534),
-           DTMFString: String
-    
+            DTMFString: String,
+            CallId_: (0..65534)
+
     command 'Dial' => :dial,
             Number:  String,
             Protocol_: [:H320, :H323, :Sip, :Spark],

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -144,7 +144,7 @@ class Cisco::CollaborationEndpoint::Ui
     def unbind
         logger.debug 'unbinding'
 
-        unsubscribe @event_binder
+        unsubscribe @event_binder if @event_binder
         @event_binder = nil
 
         clear_events

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -95,8 +95,13 @@ class Cisco::CollaborationEndpoint::Ui
 
         logger.debug { "#{id} #{type}" }
 
-        # Track values of stateful widgets as module state vars
-        self[id] = value unless BUTTON_EVENT.include?(type) && value == ''
+        # Track values of stateful widgets as module state vars or provide an
+        # event stream for button based widgets
+        self[id] = if BUTTON_EVENT.include?(type) && value == ''
+                       type
+                   else
+                       value
+                   end
 
         # Trigger any bindings defined for the widget action
         begin

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -67,7 +67,23 @@ class Cisco::CollaborationEndpoint::Ui
 
 
     # ------------------------------
+    # Panel interaction
 
+    def close_panel
+        codec.xcommand 'UserInterface Extensions Panel Close'
+    end
+
+    def on_extensions_panel_clicked(event)
+        id = event[:PanelId]
+
+        logger.debug { "#{id} opened" }
+
+        self[:__active_panel] = id
+    end
+
+    # FIXME: at the time of writing, the device API does not provide the ability
+    # to monitor for user initiated panel close events. When available, track
+    # these and update self[:__active_panel] accordingly.
 
 
     # ------------------------------

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -203,6 +203,7 @@ class Cisco::CollaborationEndpoint::Ui
             next unless notify.value
             subscribe_events
             yield if block_given?
+            sync_widget_state
         end
 
         @codec_mod
@@ -274,6 +275,21 @@ class Cisco::CollaborationEndpoint::Ui
 
         each_mapping(**opts) do |path, _, codec|
             codec.clear_event path
+        end
+    end
+
+    # Push the current module state to device widget state.
+    def sync_widget_state
+        @__config__.status.each do |key, value|
+            # Non-widget related status prefixed with `__`
+            next if key =~ /^__.*/
+
+            # Map bool values back to :on | :off
+            if [true, false].include? value
+                switch key, value
+            else
+                set key, value
+            end
         end
     end
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -131,14 +131,14 @@ class Cisco::CollaborationEndpoint::Ui
     # ------------------------------
     # Popup messages
 
-    def msg_alert(text, title: '', duration: 0)
+    def alert(text, title: '', duration: 0)
         codec.xcommand 'UserInterface Message Alert Display',
                        Text: text,
                        Title: title,
                        Duration: duration
     end
 
-    def msg_alert_clear
+    def clear_alert
         codec.xcommand 'UserInterface Message Alert Clear'
     end
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -87,21 +87,14 @@ class Cisco::CollaborationEndpoint::Ui
         end
     end
 
-    BUTTON_EVENT = [:pressed, :released, :clicked].freeze
-
     # Callback for changes to widget state.
     def on_extensions_widget_action(event)
         id, value, type = event.values_at :WidgetId, :Value, :Type
 
         logger.debug { "#{id} #{type}" }
 
-        # Track values of stateful widgets as module state vars or provide an
-        # event stream for button based widgets
-        self[id] = if BUTTON_EVENT.include?(type) && value == ''
-                       type
-                   else
-                       value
-                   end
+        # Track values of stateful widgets
+        self[id] = value unless value == ''
 
         # Trigger any bindings defined for the widget action
         begin
@@ -109,6 +102,9 @@ class Cisco::CollaborationEndpoint::Ui
         rescue => e
             logger.error "error in binding for #{id}.#{type}: #{e}"
         end
+
+        # Provide an event stream for other modules to subscribe to
+        self[:__event_stream] = { id: id, type: type, value: value }
     end
 
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -41,7 +41,7 @@ class Cisco::CollaborationEndpoint::Ui
         end
 
         bind(codec_mod) do
-            deploy_extensions 'test', ui_layout if ui_layout
+            deploy_extensions 'ACA', ui_layout if ui_layout
         end
     end
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -70,6 +70,21 @@ class Cisco::CollaborationEndpoint::Ui
     end
 
 
+    # ------------------------------
+    # Popup messages
+
+    def msg_alert(text, title: '', duration: 0)
+        codec.xcommand 'UserInterface Message Alert Display',
+                       Text: text,
+                       Title: title,
+                       Duration: duration
+    end
+
+    def msg_alert_clear
+        codec.xcommand 'UserInterface Message Alert Clear'
+    end
+
+
     protected
 
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -119,7 +119,7 @@ class Cisco::CollaborationEndpoint::Ui
     end
 
     # Set the state of a switch widget.
-    def switch(id, state)
+    def switch(id, state = !self[id])
         value = is_affirmative?(state) ? :on : :off
         set id, value
     end

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -28,8 +28,8 @@ class Cisco::CollaborationEndpoint::Ui
 
     def on_update
         codec_mod = setting(:codec) || :VidConf
-        ui_layout = setting :cisco_ui_layout
-        bindings  = setting :cisco_ui_bindings || {}
+        ui_layout = setting(:cisco_ui_layout)
+        bindings  = setting(:cisco_ui_bindings) || {}
 
         # Allow UI layouts to be stored as JSON
         if ui_layout.is_a? Hash

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -244,11 +244,8 @@ class Cisco::CollaborationEndpoint::Ui
             proc do |value|
                 logger.debug { "proxying event to #{mod}.#{method}" }
                 proxy = system[mod]
-                case proxy.arity method
-                when 0 then proxy.send method
-                when 1 then proxy.send method, value
-                else raise "incompatible binding (#{action})"
-                end
+                args  = proxy.arity(method).zero? ? nil : value
+                proxy.send method, *args
             end
 
         # Explicit / static arguments

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -93,7 +93,14 @@ class Cisco::CollaborationEndpoint::Ui
 
     # Set the value of a widget.
     def set(id, value)
-        return unset id if value.nil?
+        case value
+        when nil
+            return unset id
+        when true, false
+            # FIXME: the can result in an error being logged due to the inital
+            # type mismatch - need a neater way to handle loss of info
+            return switch(id, value).catch { highlight id, value }
+        end
 
         logger.debug { "setting #{id} to #{value}" }
 
@@ -284,15 +291,7 @@ class Cisco::CollaborationEndpoint::Ui
         @__config__.status.each do |key, value|
             # Non-widget related status prefixed with `__`
             next if key =~ /^__.*/
-
-            # Map bool values back to :on|:off or :active|:inactive
-            if [true, false].include? value
-                # FIXME: the results in an error being logged due to the inital
-                # type mismatch - need a neater way to handle loss of info
-                switch(key, value).catch { highlight(key, value) }
-            else
-                set key, value
-            end
+            set key, value
         end
     end
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -285,9 +285,11 @@ class Cisco::CollaborationEndpoint::Ui
             # Non-widget related status prefixed with `__`
             next if key =~ /^__.*/
 
-            # Map bool values back to :on | :off
+            # Map bool values back to :on|:off or :active|:inactive
             if [true, false].include? value
-                switch key, value
+                # FIXME: the results in an error being logged due to the inital
+                # type mismatch - need a neater way to handle loss of info
+                switch(key, value).catch { highlight(key, value) }
             else
                 set key, value
             end

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Cisco; end
+module CollaborationEndpoint; end
+
+class Cisco::CollaborationEndpoint::Ui
+    include ::Orchestrator::Constants
+
+    descriptive_name 'Cisco UI'
+    generic_name :CiscoUI
+    implements :logic
+    description 'Cisco Touch 10 UI extensions'
+
+
+    # ------------------------------
+    # Module callbacks
+
+    def on_load
+        on_update
+    end
+
+    def on_unload
+        unbind
+    end
+
+    def on_update
+        bind setting(:codec) || :VidConf
+    end
+
+
+    # ------------------------------
+    # Device event callbacks
+
+    def on_extensions_widget_action(event)
+        logger.debug event
+    end
+
+    def on_presentation_externalsource(event)
+        logger.debug event
+
+        source_id = event.dig :Selected, :SourceIdentifier
+        self[:external_source] = source_id
+        # FIXME: clear on sharing stop instead?
+        signal_status(:external_source)
+    end
+
+
+    protected
+
+
+    # ------------------------------
+    # Internals
+
+    # Bind to a Cisco CE device module.
+    #
+    # @param mod [Symbol] the id of the Cisco CE device module to bind to
+    def bind(mod)
+        logger.debug "binding to #{mod}"
+
+        @codec_mod = mod.to_sym
+
+        unsubscribe @event_binder if @event_binder
+        @event_binder = system.subscribe(@codec_mod, :connected) do |notify|
+            connected = notify.value
+            subscribe_events if connected
+        end
+
+        @codec_mod
+    end
+
+    # Unbind from the device module.
+    def unbind
+        logger.debug 'unbinding'
+
+        unsubscribe @event_binder
+        @event_binder = nil
+
+        clear_events
+
+        @codec_mod = nil
+    end
+
+    def bound?
+        @codec_mod.nil?.!
+    end
+
+    def codec
+        raise 'not currently bound to a codec module' unless bound?
+        system[@codec_mod]
+    end
+
+    def ui_callbacks
+        public_methods(false).each_with_object([]) do |method, callbacks|
+            next if ::Orchestrator::Core::PROTECTED[method]
+            callbacks << method if method[0..2] == 'on_'
+        end
+    end
+
+    def event_mappings
+        ui_callbacks.map do |cb|
+            path = "/Event/UserInterface/#{cb[3..-1].tr! '_', '/'}"
+            [path, cb]
+        end
+    end
+
+    def subscribe_events
+        event_mappings.map do |path, cb|
+            codec.on_event path, @__config__.settings.id, cb
+        end
+    end
+
+    def clear_events
+        event_mappings.map do |path, _|
+            codec.clear_event path
+        end
+    end
+end

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -132,8 +132,8 @@ class Cisco::CollaborationEndpoint::Ui
 
         unsubscribe @event_binder if @event_binder
         @event_binder = system.subscribe(@codec_mod, :connected) do |notify|
-            connected = notify.value
-            subscribe_events if connected
+            next unless notify.value
+            subscribe_events
             yield if block_given?
         end
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -128,6 +128,8 @@ class Cisco::CollaborationEndpoint::Ui
 
         @codec_mod = mod.to_sym
 
+        thread.all(clear_events).value
+
         unsubscribe @event_binder if @event_binder
         @event_binder = system.subscribe(@codec_mod, :connected) do |notify|
             connected = notify.value

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -161,13 +161,19 @@ class Cisco::CollaborationEndpoint::Ui
         system[@codec_mod]
     end
 
+    # Build a list of all callback methods that have been defined.
+    #
+    # Callback methods are denoted being single arity and beginning with `on_`.
     def ui_callbacks
-        public_methods(false).each_with_object([]) do |method, callbacks|
-            next if ::Orchestrator::Core::PROTECTED[method]
-            callbacks << method if method[0..2] == 'on_'
+        public_methods(false).each_with_object([]) do |name, callbacks|
+            next if ::Orchestrator::Core::PROTECTED[name]
+            next unless name[0..2] == 'on_'
+            next unless method(name).arity == 1
+            callbacks << name
         end
     end
 
+    # Build a list of device XPath -> callback mappings.
     def event_mappings
         ui_callbacks.map do |cb|
             path = "/Event/UserInterface/#{cb[3..-1].tr! '_', '/'}"

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -125,9 +125,10 @@ class Cisco::CollaborationEndpoint::Ui
     end
 
     # Set the highlight state for a button widget.
-    def highlight(id, state)
+    def highlight(id, state = true, momentary: false, time: 500)
         value = is_affirmative?(state) ? :active : :inactive
         set id, value
+        schedule.in(time) { highlight id, !value } if momentary
     end
 
     # Set the text label used on text or spinner widget.

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -47,14 +47,6 @@ class Cisco::CollaborationEndpoint::Ui
 
 
     # ------------------------------
-    # Device event callbacks
-
-    def on_extensions_widget_action(event)
-        logger.debug event
-    end
-
-
-    # ------------------------------
     # UI deployment
 
     def deploy_extensions(id, xml_def)
@@ -67,6 +59,36 @@ class Cisco::CollaborationEndpoint::Ui
 
     def clear_extensions
         codec.xcommand 'UserInterface Extensions Clear'
+    end
+
+
+    # ------------------------------
+    # UI element interaction
+
+    def widget(id, value)
+        case value
+        when nil
+            codec.xcommand 'UserInterface Extensions Widget UnsetValue',
+                           WidgetId: id
+        when true
+            widget id, :on
+        when false
+            widget id, :off
+        else
+            codec.xcommand 'UserInterface Extensions Widget SetValue',
+                           Value: value, WidgetId: id
+        end
+    end
+
+    BUTTON_EVENT = [:pressed, :released, :clicked].freeze
+
+    def on_extensions_widget_action(event)
+        id, value, type = event.values_at :WidgetId, :Value, :Type
+
+        logger.debug { "#{id} #{type}" }
+
+        # Track values of stateful widgets as module state vars
+        self[id] = value unless BUTTON_EVENT.include?(type) && value == ''
     end
 
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -137,7 +137,7 @@ class Cisco::CollaborationEndpoint::Ui
     #
     # @param mod [Symbol] the id of the Cisco CE device module to bind to
     def bind(mod)
-        logger.debug "binding to #{mod}"
+        logger.debug { "binding to #{mod}" }
 
         @codec_mod = mod.to_sym
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -49,14 +49,17 @@ class Cisco::CollaborationEndpoint::Ui
     # ------------------------------
     # UI deployment
 
+    # Push a UI definition build with the in-room control editor to the device.
     def deploy_extensions(id, xml_def)
         codec.xcommand 'UserInterface Extensions Set', xml_def, ConfigId: id
     end
 
+    # Retrieve the extensions currently loaded.
     def list_extensions
         codec.xcommand 'UserInterface Extensions List'
     end
 
+    # Clear any deployed UI extensions.
     def clear_extensions
         codec.xcommand 'UserInterface Extensions Clear'
     end
@@ -65,23 +68,27 @@ class Cisco::CollaborationEndpoint::Ui
     # ------------------------------
     # UI element interaction
 
+    # Set the value of a custom UI widget.
     def widget(id, value)
+        widget_action = lambda do |action, **args|
+            codec.xcommand "UserInterface Extensions Widget #{action}", args
+        end
+
         case value
         when nil
-            codec.xcommand 'UserInterface Extensions Widget UnsetValue',
-                           WidgetId: id
+            widget_action[:UnsetValue, WidgetId: id]
         when true
             widget id, :on
         when false
             widget id, :off
         else
-            codec.xcommand 'UserInterface Extensions Widget SetValue',
-                           Value: value, WidgetId: id
+            widget_action[:SetValue, WidgetId: id, Value: value]
         end
     end
 
     BUTTON_EVENT = [:pressed, :released, :clicked].freeze
 
+    # Callback for changes to widget state.
     def on_extensions_widget_action(event)
         id, value, type = event.values_at :WidgetId, :Value, :Type
 

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -67,25 +67,45 @@ class Cisco::CollaborationEndpoint::Ui
 
 
     # ------------------------------
-    # UI element interaction
 
-    # Set the value of a custom UI widget.
-    def widget(id, value)
-        widget_action = lambda do |action, **args|
-            codec.xcommand "UserInterface Extensions Widget #{action}", args
-        end
 
-        case value
-        when nil
-            widget_action[:UnsetValue, WidgetId: id]
-        when true
-            widget id, :on
-        when false
-            widget id, :off
-        else
-            widget_action[:SetValue, WidgetId: id, Value: value]
+
+    # ------------------------------
+    # Element interaction
+
+    # Set the value of a widget.
+    def set(id, value)
+        return unset id if value.nil?
+
+        logger.debug { "setting #{id} to #{value}" }
+
+        codec.xcommand 'UserInterface Extensions Widget SetValue',
+                       WidgetId: id, Value: value
         end
     end
+
+    # Clear the value associated with a widget.
+    def unset(id)
+        logger.debug { "clearing #{id}" }
+
+        codec.xcommand 'UserInterface Extensions Widget UnsetValue',
+                       WidgetId: id
+    end
+
+    # Set the state of a switch widget.
+    def switch(id, state)
+        value = is_affirmative?(state) ? :on : :off
+        set id, value
+    end
+
+    # Set the highlight state for a button widget.
+    def highlight(id, state)
+        value = is_affirmative?(state) ? :active : :inactive
+        set id, value
+    end
+
+    # Set the text label used on text or spinner widget.
+    alias label set
 
     # Callback for changes to widget state.
     def on_extensions_widget_action(event)

--- a/modules/cisco/collaboration_endpoint/ui.rb
+++ b/modules/cisco/collaboration_endpoint/ui.rb
@@ -156,7 +156,7 @@ class Cisco::CollaborationEndpoint::Ui
         unsubscribe @event_binder if @event_binder
         @event_binder = nil
 
-        clear_events
+        clear_events async: true
 
         @codec_mod = nil
     end
@@ -202,18 +202,18 @@ class Cisco::CollaborationEndpoint::Ui
         result.value unless async
     end
 
-    def subscribe_events
+    def subscribe_events(**opts)
         mod_id = @__config__.settings.id
 
-        each_mapping do |path, cb, codec|
+        each_mapping(**opts) do |path, cb, codec|
             codec.on_event path, mod_id, cb
         end
     end
 
-    def clear_events
+    def clear_events(**opts)
         @event_handlers = nil
 
-        each_mapping do |path, _, codec|
+        each_mapping(**opts) do |path, _, codec|
             codec.clear_event path
         end
     end

--- a/modules/cisco/collaboration_endpoint/ui_extensions.rb
+++ b/modules/cisco/collaboration_endpoint/ui_extensions.rb
@@ -62,7 +62,9 @@ module Cisco::CollaborationEndpoint::UiExtensions
         end
     end
 
-    protected
+    def ui_extenions_deploy(id, xml_def)
+        send_xcommand 'UserInterface Extensions Set', xml_def, ConfigId: id
+    end
 
     def ui_extensions_list
         send_xcommand 'UserInterface Extensions List'

--- a/modules/cisco/collaboration_endpoint/ui_extensions.rb
+++ b/modules/cisco/collaboration_endpoint/ui_extensions.rb
@@ -62,7 +62,7 @@ module Cisco::CollaborationEndpoint::UiExtensions
         end
     end
 
-    def ui_extenions_deploy(id, xml_def)
+    def ui_extensions_deploy(id, xml_def)
         send_xcommand 'UserInterface Extensions Set', xml_def, ConfigId: id
     end
 

--- a/modules/cisco/collaboration_endpoint/ui_extensions.rb
+++ b/modules/cisco/collaboration_endpoint/ui_extensions.rb
@@ -8,19 +8,6 @@ module Cisco::CollaborationEndpoint; end
 module Cisco::CollaborationEndpoint::UiExtensions
     include ::Cisco::CollaborationEndpoint::Xapi::Mapper
 
-    module Hooks
-        def connected
-            super
-            register_feedback '/Event/UserInterface/Extensions/Widget/Action' do |action|
-                logger.debug action
-            end
-        end
-    end
-
-    def self.included(base)
-        base.prepend Hooks
-    end
-
     command 'UserInterface Message Alert Clear' => :msg_alert_clear
     command 'UserInterface Message Alert Display' => :msg_alert,
             Text: String,

--- a/modules/cisco/collaboration_endpoint/xapi/action.rb
+++ b/modules/cisco/collaboration_endpoint/xapi/action.rb
@@ -28,17 +28,15 @@ module Cisco::CollaborationEndpoint::Xapi::Action
     # Serialize an xAPI action into transmittable command.
     #
     # @param type [ACTION_TYPE] the type of action to execute
-    # @param args [String, Array<String>] the action args
-    # @param kwargs [Hash] an optional hash of keyword arguments for the action
+    # @param args [String|Hash, Array<String|Hash>] the action args
     # @return [String]
-    def create_action(type, *args, **kwargs)
+    def create_action(type, *args)
         unless ACTION_TYPE.include? type
             raise ArgumentError,
                   "Invalid action type. Must be one of #{ACTION_TYPE}."
         end
 
-        kwargs.merge! args.pop if args.last.is_a? Hash
-
+        kwargs = args.last.is_a?(Hash) ? args.pop : {}
         kwargs = kwargs.compact.map do |name, value|
             value = "\"#{value}\"" if value.is_a? String
             "#{name}: #{value}"
@@ -50,10 +48,10 @@ module Cisco::CollaborationEndpoint::Xapi::Action
     # Serialize an xCommand into transmittable command.
     #
     # @param path [String, Array<String>] command path
-    # @param args [Hash] an optional hash of keyword arguments
+    # @param kwargs [Hash] an optional hash of keyword arguments
     # @return [String]
-    def xcommand(path, args)
-        create_action :xCommand, path, **args
+    def xcommand(path, kwargs = {})
+        create_action :xCommand, path, kwargs
     end
 
     # Serialize an xConfiguration action into a transmittable command.

--- a/modules/cisco/collaboration_endpoint/xapi/response.rb
+++ b/modules/cisco/collaboration_endpoint/xapi/response.rb
@@ -64,14 +64,14 @@ module Cisco::CollaborationEndpoint::Xapi::Response
     # @param value [String] the value to convert
     # @param valuespace [Symbol] the Cisco value space reference
     # @return the value as an appropriate core datatype
-    def convert(value, valuespace)
+    def convert(value, valuespace = nil)
         parser = PARSERS[valuespace]
         if parser
             parser.call(value)
         else
             begin
                 Integer(value)
-            rescue ArgumentError
+            rescue
                 if truthy? value
                     true
                 elsif falsey? value


### PR DESCRIPTION
# Description

Provide support for integration and management of Cisco Touch 10 UI Extensions. Support is added via the 'Cisco UI' module which provides abstractions around an accompanying Cisco Collaboration Endpoint (SX80, RoomKit, SX20 etc) device driver. All integration may then be configured by settings.

### Driver Settings

#### `codec`
The ID of the device driver that should be used for comms. Defaults to `VidConf`.

#### `cisco_ui_layout`
The UI definition to push to the touch 10. This can be constructed with the on-device editor or at https://aca.im/cisco-ui-editor/. Experimental support is also provided for storage of these UI definitions as JSON via a direct XML -> JSON conversion to provide simplified editing from backoffice, however this is not recommended.

#### `cisco_ui_bindings`
Bindings provide a direct mapping between UI elements and system state and behaviour. These take the structure of `widget_id: config` where config may be:
    1. `"mod.x"`: simple two-way binding. This will exec `x` on any interaction. If mod exposes a status variable `x`, changes to this will also propagate back to the UI element state.
    2. `mod: { bindings }`: advanced binding. `bindings` is a hash mapping events to actions and `status` to a state to track. All keys are optional.
   
When specifying actions, these may be one of:
    1. `mod.method`: implicit binding - will pass the event value as a single parameter if accepted by the target
    2. `mod: { method: [params] }`: explicit binding, allows static arguments to be used

Example
```json
{
    "cisco_ui_bindings": {
        "button_1": "System.powerup",
        "slider_1": "System.volume",
        "button_2": {
            "clicked": {
                "VidConf": {
                    "dial": "support@acaprojects.com"
                }
            },
            "status": "VidConf.in_call"
        }
    }
}
```
In the config above:
+ clicking `button_1` will exec `System.powerup`
+ changing `slider_1` will exec `System.volume` and (assuming this take a volume level argument) will pass it the current slider value
+ changes to `System[:volume]` will result in `slider_1` updating to show the current value
+ clicking `button_2` will always exec `VidConf.dial("support@acaprojects.com")`
+ `button_2` will highlight when `VidConf` is `in_call`.

### Other Behavior
Regardless of bindings, all stateful widgets are tracked as status var and provide a two way binding. These may be linked to triggers, or subscribed to or interacted with by other modules for more advanced behaviour requirements.

An `:__event_stream` that updates with every widget event is also provided as a firehose to subscribe to if widget id's are not known ahead of time.

The last viewed panel is also provide under `:__active_panel`. This may be used for detecting and responding to panel open events.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New device driver
- [ ] New service driver
- [x] New logic driver
- [x] Driver update (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Has this been tested?

Check all that apply.

- [ ] As a mocked device with a spec
- [x] With a physical device
