### PR TITLE
Coriomaster: flexible window id's

### DIFF
--- a/modules/tv_one/corio_master.rb
+++ b/modules/tv_one/corio_master.rb
@@ -75,15 +75,15 @@ class TvOne::CorioMaster
 
     def switch(signal_map)
         interactions = signal_map.flat_map do |slot, windows|
-            Array(windows).map do |id|
-                id = id.to_s[/\d+/].to_i unless id.is_a? Integer
-                window id, 'Input', slot
-            end
+            Array(windows).map { |id| window id, 'Input', slot }
         end
-        thread.finally(*interactions)
+
+        thread.finally interactions
     end
 
     def window(id, property, value)
+        id = id.to_s[/\d+/].to_i unless id.is_a? Integer
+
         set("Window#{id}.#{property}", value).then do
             self[:windows] = (self[:windows] || {}).deep_merge(
                 :"window#{id}" => { property.downcase.to_sym => value }


### PR DESCRIPTION
# Description

Accept either `<id>` or `window<id>` as window refs


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New device driver
- [ ] New service driver
- [ ] New logic driver
- [x] Driver update (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Has this been tested?

Check all that apply.

- [x] As a mocked device with a spec
- [x] With a physical device
